### PR TITLE
Fix stack trace when LuaJIT FFI data is present

### DIFF
--- a/src/mobdebug.lua
+++ b/src/mobdebug.lua
@@ -104,7 +104,7 @@ local serpent = (function() ---- include Serpent module for serialization
 local n, v = "serpent", 0.225 -- (C) 2012-13 Paul Kulchenko; MIT License
 local c, d = "Paul Kulchenko", "Lua serializer and pretty printer"
 local snum = {[tostring(1/0)]='1/0 --[[math.huge]]',[tostring(-1/0)]='-1/0 --[[-math.huge]]',[tostring(0/0)]='0/0'}
-local badtype = {thread = true, userdata = true}
+local badtype = {thread = true, userdata = true, cdata = true}
 local keyword, globals, G = {}, {}, (_G or _ENV)
 for _,k in ipairs({'and', 'break', 'do', 'else', 'elseif', 'end', 'false',
   'for', 'function', 'goto', 'if', 'in', 'local', 'nil', 'not', 'or', 'repeat',


### PR DESCRIPTION
The LuaJIT FFI introduces a new Lua type `cdata`.  It is not handled specifically by MobDebug, producing an error in the Stack Window (and no stack)

This patch simply adds `cdata` to the `badtype` blacklist.  FFI types now print something like "cdata<struct foo>: 0x40a44d30".  If people want more informative cdata, they can implement a metamethod.

This patch is released under the MIT license.
