### PR TITLE
add callback mobdebug.scratch

### DIFF
--- a/src/mobdebug.lua
+++ b/src/mobdebug.lua
@@ -765,6 +765,7 @@ local function debugger_loop(sev, svars, sfile, sline)
           status, res = stringify_results(pcall(func))
         end
         if status then
+          if mobdebug.scratch then mobdebug.scratch(res) end
           server:send("200 OK " .. tostring(#res) .. "\n")
           server:send(res)
         else
@@ -1591,6 +1592,7 @@ mobdebug.coro = coro
 mobdebug.done = done
 mobdebug.pause = function() step_into = true end
 mobdebug.yield = nil -- callback
+mobdebug.scratch = nil -- callback
 mobdebug.basedir = function(b) if b then basedir = b end return basedir end
 
 -- this is needed to make "require 'modebug'" to work when mobdebug


### PR DESCRIPTION
This callback is triggered each time the debugger successfully exec'd a new function eg received from a scratchpad.

I found it quit useful eg in a framework to get notified when the scratchpad reloads and trigger some setup functions.