### PR TITLE
#60 Update MobDebug to work with luasocket 3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 # MobDebug Changelog
 
+## v0.71 (May 30 2021)
+  - Updated the usages of receive to be compatible with luasocket version 3
 ## v0.70 (Sep 02 2017)
   - Upgraded Serpent (0.30) to allow skipping `__tostring` (closes #27, closes #29).
   - Improved handling of `__tostring` failures in stack processing (#27, #29).

--- a/misc/mobdebug-0.80-1.rockspec
+++ b/misc/mobdebug-0.80-1.rockspec
@@ -1,0 +1,48 @@
+package = "MobDebug"
+version = "0.80-1"
+
+source = {
+   url = "git://github.com/pkulchenko/MobDebug.git",
+   tag = "0.80"
+}
+
+description = {
+   summary = "MobDebug is a remote debugger for the Lua programming language",
+   detailed = [[
+      MobDebug allows you control the execution of another Lua program remotely,
+      set breakpoints, and inspect the current state of the program.
+
+      MobDebug is based on [RemDebug](http://www.keplerproject.org/remdebug/) and
+      extends it in several ways:
+
+      * added new commands: LOAD, RELOAD, OUT, STACK, DONE;
+      * added support for debugging wxwidgets applications;
+      * added ability to pause and abort running applications;
+      * added pretty printing and handling of multiple results in EXEC;
+      * added stack and local/upvalue value reporting (STACK);
+      * added on/off commands to turn debugging on and off (to improve performance);
+      * added support for coroutine debugging (see examples/README for details);
+      * added support for [Moai](http://getmoai.com/) debugging;
+      * added support for Lua 5.2 and Lua 5.3;
+      * added support for LuaJIT debugging;
+      * added support for nginx/OpenResty and Lapis debugging;
+      * added support for cross-platform debugging (with client and server running on different platforms/filesystems);
+      * removed dependency on LuaFileSystem;
+      * provided integration with [ZeroBrane Studio IDE](http://studio.zerobrane.com/).
+   ]],
+   license = "MIT/X11",
+   homepage = "https://github.com/pkulchenko/MobDebug"
+}
+
+dependencies = {
+   "lua >= 5.1, < 5.4",
+   "luasocket >= 3.0"
+}
+
+build = {
+   type = "builtin",
+   modules = {
+      ["mobdebug"] = "src/mobdebug.lua",
+   },
+   copy_directories = { "examples" }
+}

--- a/src/mobdebug.lua
+++ b/src/mobdebug.lua
@@ -19,7 +19,7 @@ end)("os")
 
 local mobdebug = {
   _NAME = "mobdebug",
-  _VERSION = "0.709",
+  _VERSION = "0.801",
   _COPYRIGHT = "Paul Kulchenko",
   _DESCRIPTION = "Mobile Remote Debugger for the Lua programming language",
   port = os and os.getenv and tonumber((os.getenv("MOBDEBUG_PORT"))) or 8172,


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/35623921/120112007-bfa06f00-c17c-11eb-859c-374ab0c8a989.png)
The error received is that luasocket 3 receive primitive even if it has a default it must be explicitly passed to the function.
http://w3.impa.br/~diego/software/luasocket/tcp.html#receive
![image](https://user-images.githubusercontent.com/35623921/120116314-47dc3f80-c190-11eb-8152-97a37c125eff.png)
So, what I did is I created a fork of the project and replaced all the
```receive()``` calls with calls with explicit "default" argument ```receive('*l')```(which is the default).
This affects EmmyLua Intellij IDEA and also LuaAnalysis(derived from EmmyLua).
This fixes [the bug opened by me](https://github.com/pkulchenko/MobDebug/issues/60)
