### PR TITLE
rawget(genv, "ngx") doesn't work

### DIFF
--- a/src/mobdebug.lua
+++ b/src/mobdebug.lua
@@ -55,7 +55,8 @@ local MOAICoroutine = rawget(genv, "MOAICoroutine")
 -- methods use a different mechanism that doesn't allow resume calls
 -- from debug hook handlers.
 -- Instead, the "original" coroutine.* methods are used.
-local ngx = rawget(genv, "ngx")
+local metagindex = getmetatable(genv) and getmetatable(genv).__index
+local ngx = rawget(genv, "ngx") or type(metagindex) == "table" and metagindex.rawget and metagindex:rawget("ngx") or nil
 local corocreate = ngx and coroutine._create or coroutine.create
 local cororesume = ngx and coroutine._resume or coroutine.resume
 local coroyield = ngx and coroutine._yield or coroutine.yield


### PR DESCRIPTION
Hello,

I'm on debian buster, and when I try to debug a lua script called in nginx, MobDebug works on version 706, but not on the latest.

It seems that the change in the way we retrieve ngx is not working properly on my end and `rawget(genv, "ngx")` returns `nil` . Since I am not a lua developer, I put the previous version with the metagindexes and stuff next to the current way we retrieve it.

I remain at your disposal for further information.

Edit:

FYI my lua scripts is called with `access_by_lua_file` in a `server` section.

When I evaluate `genv`:
```
>>> genv
{_G = nil --[[ref]], __ngx_req = __ngx_req --[[userdata: 0x561db069ee20]]} --[[table: 0x41db3b50]] --[[incomplete output with shared/self-references skipped]]
```

When I evaluate `getmetatable(genv)`, I have many elements, including ngx