### PR TITLE
fix crash in some circumstances when debugging using IntelliJ-EmmyLua

### DIFF
--- a/src/mobdebug.lua
+++ b/src/mobdebug.lua
@@ -794,8 +794,11 @@ local function debugger_loop(sev, svars, sfile, sline)
       end
     end
     if server.settimeout then server:settimeout() end -- back to blocking
-    command = string.sub(line, string.find(line, "^[A-Z]+"))
-    if command == "SETB" then
+    local status
+    status, command = pcall(string.sub, line, string.find(line, "^[A-Z]+"))
+    if not status then
+      print('error getting the command')
+    elseif command == "SETB" then
       local _, _, _, file, line = string.find(line, "^([A-Z]+)%s+(.-)%s+(%d+)%s*$")
       if file and line then
         set_breakpoint(file, tonumber(line))


### PR DESCRIPTION
**Problem**: MobDebug crashes when debugging using IntelliJ-EmmyLua.
Example:
```
line:   EXEC return {
line:         get = 'GET_single-senders-senderId';

./apis/nmos.lua:309: /usr/share/lua/5.4/mobdebug.lua:812: bad argument #2 to 'sub' (number expected, got nil) stack traceback:
        [C]: in function 'error'
        /usr/share/lua/5.4/mobdebug.lua:719: in hook '?'
        ...
```
**Solution**: wrap `string.sub` in `pcall`.